### PR TITLE
feat(env variables): add .env for debug, production, and development

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,12 @@
+VITE_APP_URL="http://localhost:3000"
+VITE_WS_URL="ws://localhost:3000/cable"
+VITE_HOST_URL="http://localhost:5173"
+
+# Valores posibles: production | development | debug
+VITE_ENVIRONMENT="development"
+
+# Tenant—sucursal que consume el sistema
+VITE_TENANT="previsora"
+
+# Token específico de cada subdominio
+VITE_TENANT_TOKEN="eden-qjy7b3b3yfdv9x15jpi-1d531bmugjc891rlhb1481zqvff0r-cuyxa69afq5laif98m"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:debug": "vite --mode debug",
     "build": "tsc -b && vite build",
+    "build:staging": "tsc -b && vite build --mode debug",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "echo \"No tests specified\" && exit 0",

--- a/src/env/.env.debug
+++ b/src/env/.env.debug
@@ -1,0 +1,6 @@
+VITE_APP_URL="http://staging.myapp.com"
+VITE_WS_URL="ws://staging.myapp.com/cable"
+VITE_HOST_URL="http://localhost:5173"
+VITE_ENVIRONMENT="debug"
+VITE_TENANT="jardin"
+VITE_TENANT_TOKEN=""

--- a/src/env/.env.development
+++ b/src/env/.env.development
@@ -1,0 +1,7 @@
+VITE_APP_URL="http://localhost:3000"
+VITE_WS_URL="ws://localhost:3000/cable"
+VITE_HOST_URL="http://localhost:5173"
+VITE_ENVIRONMENT="development"
+VITE_TENANT="previsora"
+# no versionar esto:
+VITE_TENANT_TOKEN="TOKEN_DE_PRUEBA"

--- a/src/env/.env.production
+++ b/src/env/.env.production
@@ -1,0 +1,6 @@
+VITE_APP_URL="https://api.myapp.com"
+VITE_WS_URL="wss://api.myapp.com/cable"
+VITE_HOST_URL="https://app.myapp.com"
+VITE_ENVIRONMENT="production"
+VITE_TENANT="previsora"
+VITE_TENANT_TOKEN="" 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,23 +1,36 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
+import type { ConfigEnv } from 'vite'
 import react from '@vitejs/plugin-react-swc'
 import tailwindcss from '@tailwindcss/vite'
-import path from "path"
+import path from 'path'
 
-// https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss(),],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@components": path.resolve(__dirname, "./src/components"),
-      "@config": path.resolve(__dirname, "./src/config"),
-      "@pages": path.resolve(__dirname, "./src/pages"),
-      "@assets": path.resolve(__dirname, "./src/assets"),
-      "@lib": path.resolve(__dirname, "./src/lib"),
-      "@hooks": path.resolve(__dirname, "./src/hooks"),
-      "@core": path.resolve(__dirname, "./src/core"),
-      "@store": path.resolve(__dirname, "./src/config/store"),
-      "@layouts": path.resolve(__dirname, "./src/layouts"),
+export default ({ mode }: ConfigEnv) => {
+  // carga .env.<mode> desde ./env
+  const env = loadEnv(mode, path.resolve(__dirname, 'env'), 'VITE_')
+  // prepara el objeto para injectar en define
+  const defineEnv = Object.fromEntries(
+    Object.entries(env).map(([k, v]) => [k, JSON.stringify(v)])
+  )
+
+  return defineConfig({
+    define: {
+      // expone las vars a process.env en el bundle
+      'process.env': defineEnv
     },
-  },
-})
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+        "@components": path.resolve(__dirname, "./src/components"),
+        "@config": path.resolve(__dirname, "./src/config"),
+        "@pages": path.resolve(__dirname, "./src/pages"),
+        "@assets": path.resolve(__dirname, "./src/assets"),
+        "@lib": path.resolve(__dirname, "./src/lib"),
+        "@hooks": path.resolve(__dirname, "./src/hooks"),
+        "@core": path.resolve(__dirname, "./src/core"),
+        "@store": path.resolve(__dirname, "./src/config/store"),
+        "@layouts": path.resolve(__dirname, "./src/layouts"),
+      },
+    },
+  })
+}


### PR DESCRIPTION
This pull request introduces environment-specific configurations and updates the build process to better handle multiple environments (development, debug, staging, and production). Key changes include the addition of `.env` files for each environment, updates to the `vite.config.ts` file to dynamically load environment variables, and new scripts in `package.json` for debugging and staging builds.

### Environment Configuration Updates:

* Added `.env` files for `development`, `debug`, and `production` environments, each containing environment-specific variables such as `VITE_APP_URL`, `VITE_WS_URL`, `VITE_ENVIRONMENT`, and `VITE_TENANT` (`src/env/.env.development`, `src/env/.env.debug`, `src/env/.env.production`) [[1]](diffhunk://#diff-684a0eaa3115a63e2341bc676707dbf616a4bb57e6dbb03f750124dc7924bfd4R1-R6) [[2]](diffhunk://#diff-cd731c24fd33480e71799cc18460dfe1113ab38a78c0307f5e36eefbb0273b52R1-R7) [[3]](diffhunk://#diff-8957cb6102969d3b1617fd7c52a5cdaabdd1479610baf620abd235f622583426R1-R6).
* Updated the root `.env` file with default environment variables, including a placeholder `VITE_TENANT_TOKEN` for tenant-specific tokens (`.env`).

### Build Process Enhancements:

* Modified `vite.config.ts` to dynamically load environment variables based on the build mode (`development`, `debug`, `production`, etc.). This ensures that the correct `.env` file is loaded during the build process (`vite.config.ts`).
* Added a new `define` property in `vite.config.ts` to expose environment variables as `process.env` in the bundled code (`vite.config.ts`).

### New Scripts in `package.json`:

* Added `dev:debug` script for running the development server in debug mode and `build:staging` script for creating a staging build (`package.json`).